### PR TITLE
Introduce Email Verification, Refractoring + Other changes

### DIFF
--- a/client/src/components/Right/Right.tsx
+++ b/client/src/components/Right/Right.tsx
@@ -47,6 +47,7 @@ export default function Right() {
 
     useEffect(() => {
         getNotifications().then((res) => {
+            if (Object.keys(res.data).length === 0) return;
             setNotifications(
                 res.data.map(
                     (notification: {

--- a/server/migrations/0003_email_verification.sql
+++ b/server/migrations/0003_email_verification.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS email_verification
+(
+    token      TEXT PRIMARY KEY,
+    user_id    INTEGER NOT NULL,
+    email      TEXT    NOT NULL,
+    used       BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE
+);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0",
             "dependencies": {
                 "@cloudflare/types": "^6.29.1",
+                "@sendgrid/mail": "^8.1.4",
                 "bcryptjs": "^2.4.3",
                 "google-auth-library": "^9.15.0",
                 "hono": "^4.6.3",
@@ -1936,6 +1937,44 @@
                 "win32"
             ]
         },
+        "node_modules/@sendgrid/client": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.4.tgz",
+            "integrity": "sha512-VxZoQ82MpxmjSXLR3ZAE2OWxvQIW2k2G24UeRPr/SYX8HqWLV/8UBN15T2WmjjnEb5XSmFImTJOKDzzSeKr9YQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@sendgrid/helpers": "^8.0.0",
+                "axios": "^1.7.4"
+            },
+            "engines": {
+                "node": ">=12.*"
+            }
+        },
+        "node_modules/@sendgrid/helpers": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+            "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+            "license": "MIT",
+            "dependencies": {
+                "deepmerge": "^4.2.2"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@sendgrid/mail": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.4.tgz",
+            "integrity": "sha512-MUpIZykD9ARie8LElYCqbcBhGGMaA/E6I7fEcG7Hc2An26QJyLtwOaKQ3taGp8xO8BICPJrSKuYV4bDeAJKFGQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@sendgrid/client": "^8.1.4",
+                "@sendgrid/helpers": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=12.*"
+            }
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2983,8 +3022,18 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/axios": {
+            "version": "1.7.9",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+            "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -3213,7 +3262,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
@@ -3284,6 +3332,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/defu": {
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
@@ -3295,7 +3352,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -3505,11 +3561,30 @@
                 "fxparser": "src/cli/cli.js"
             }
         },
+        "node_modules/follow-redirects": {
+            "version": "1.15.9",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
             "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -3974,7 +4049,6 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -3984,7 +4058,6 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
@@ -4268,6 +4341,12 @@
             "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
             "dev": true,
             "license": "Unlicense"
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "license": "MIT"
         },
         "node_modules/qs": {
             "version": "6.13.1",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
     },
     "dependencies": {
         "@cloudflare/types": "^6.29.1",
+        "@sendgrid/mail": "^8.1.4",
         "bcryptjs": "^2.4.3",
         "google-auth-library": "^9.15.0",
         "hono": "^4.6.3",

--- a/server/src/dev.schema.sql
+++ b/server/src/dev.schema.sql
@@ -51,6 +51,18 @@ CREATE TABLE IF NOT EXISTS session
     FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE
 );
 
+/* Email verification Table */
+
+CREATE TABLE IF NOT EXISTS email_verification
+(
+    token      TEXT PRIMARY KEY,
+    user_id    INTEGER NOT NULL,
+    email      TEXT    NOT NULL,
+    used       BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE
+);
+
 /* Community Table */
 
 CREATE TABLE IF NOT EXISTS community

--- a/server/src/v3/controllers/auth.controller.ts
+++ b/server/src/v3/controllers/auth.controller.ts
@@ -112,7 +112,7 @@ export async function signup(c: Context) {
             if (!user) return c.json({ message: 'Internal Server Error', status: 500 }, 500);
 
             // Generate Session Key & Salt
-            const PlainSessionKey = crypto.randomUUID();
+            const PlainSessionKey = randomBytes(32).toString('hex');
             const sessionKey = await hashSessionKey(PlainSessionKey);
 
             // const { encoded: sessionKeyEncoded } = generateSalt();
@@ -197,7 +197,7 @@ export async function authenticateWithGoogle(c: Context) {
 
         // If user exists, generate session key & token
         if (user) {
-            const PlainSessionKey = crypto.randomUUID();
+            const PlainSessionKey = randomBytes(32).toString('hex');
             const sessionKey = await hashSessionKey(PlainSessionKey);
 
             c.executionCtx.waitUntil(
@@ -236,7 +236,7 @@ export async function authenticateWithGoogle(c: Context) {
             if (!newUser) return c.json({ message: 'Internal Server Error', status: 500 }, 500);
 
             // Generate session key & token
-            const PlainSessionKey = crypto.randomUUID();
+            const PlainSessionKey = randomBytes(32).toString('hex');
             const sessionKey = await hashSessionKey(PlainSessionKey);
 
             // Send cookies
@@ -300,7 +300,7 @@ export async function anonSignup(c: Context, returnInternal: boolean = false) {
         if (!user) return c.json({ message: 'Internal Server Error', status: 500 }, 500);
 
         // All good, generate session key & hash it
-        const PlainSessionKey = crypto.randomUUID();
+        const PlainSessionKey = randomBytes(32).toString('hex');
         const sessionKey = await hashSessionKey(PlainSessionKey);
 
         // const { encoded } = generateSalt();
@@ -366,7 +366,7 @@ export async function login(c: Context) {
         `).bind(user.id).first<UserView>();
 
         // Generate Session Key & Salt
-        const PlainSessionKey = crypto.randomUUID();
+        const PlainSessionKey = randomBytes(32).toString('hex');
         const sessionKey = await hashSessionKey(PlainSessionKey);
 
         // const { encoded: sessionKeyEncoded } = generateSalt();

--- a/server/src/v3/controllers/notification.controller.ts
+++ b/server/src/v3/controllers/notification.controller.ts
@@ -8,10 +8,10 @@ export async function getNotifications(c: Context) {
     const isAnonymous = c.get('isAnonymous') as boolean;
 
     // Check if user is valid and not anonymous
-    if (!userId || isAnonymous) return c.text('Unauthorized', { status: 401 });
+    if (!userId || isAnonymous) return c.json({}, { status: 200 });
 
-    // Get page from query
-    const page = parseInt(c.req.query('page') as string) || 0;
+    // Get offset from query
+    const offset = parseInt(c.req.query('offset') as string) || 0;
 
     try {
         // Get notifications
@@ -20,7 +20,7 @@ export async function getNotifications(c: Context) {
             FROM notification_view
             WHERE recipient_id = ?
             LIMIT 10 OFFSET ?
-        `).bind(userId, page * 10).all<NotificationView>();
+        `).bind(userId, offset).all<NotificationView>();
 
         // Define function for handling hidden entities
         // This is used for including a post's content after a like for example

--- a/server/src/v3/controllers/post.controller.ts
+++ b/server/src/v3/controllers/post.controller.ts
@@ -95,7 +95,6 @@ export async function getLatestPosts(c: Context) {
         } else {
             // Returning user, show posts with likes
             const posts = await env.DB.prepare(
-                `SELECT pv.*
                 `SELECT pv.*,
                         EXISTS (SELECT 1
                                 FROM post_like
@@ -104,17 +103,7 @@ export async function getLatestPosts(c: Context) {
                  FROM post_view AS pv
                  ORDER BY pv.post_time DESC
                  LIMIT 10 OFFSET ?`
-            ).bind(offset).all<PostView>();
-            // const posts = await env.DB.prepare(
-            //     `SELECT pv.*,
-            //             EXISTS (SELECT 1
-            //                     FROM post_like
-            //                     WHERE post_like.post_id = pv.id
-            //                       AND post_like.user_id = ?) AS liked
-            //      FROM post_view AS pv
-            //      ORDER BY pv.post_time DESC
-            //      LIMIT 10 OFFSET ?`
-            // ).bind(userId, offset).all<PostView>();
+            ).bind(userId, offset).all<PostView>();
 
             return c.json(posts.results, { status: 200 });
         }
@@ -198,8 +187,8 @@ export async function getLatestPostsFromMyCommunities(c: Context) {
                       JOIN user_community AS uc ON pv.community_id = uc.community_id
              WHERE uc.user_id = ?
              ORDER BY pv.post_time DESC
-             LIMIT 10 OFFSET (? * 10)`
-        ).bind(userId, userId, offset || 0).all<PostView>();
+             LIMIT 10 OFFSET ?`
+        ).bind(userId, userId, offset).all<PostView>();
 
         return c.json(posts.results, { status: 200 });
     } catch (e) {
@@ -236,8 +225,8 @@ export async function getBestPostsFromMyCommunities(c: Context) {
                       JOIN user_community AS uc ON pv.community_id = uc.community_id
              WHERE uc.user_id = ?
              ORDER BY score DESC
-             LIMIT 10 OFFSET (? * 10)`
-        ).bind(userId, userId, offset || 0).all<PostView>();
+             LIMIT 10 OFFSET ?`
+        ).bind(userId, userId, offset).all<PostView>();
 
         return c.json(posts.results, { status: 200 });
     } catch (e) {
@@ -271,7 +260,7 @@ export async function getPostsByUser(c: Context) {
                     OR pv.author_id = ?
                  ORDER BY pv.post_time DESC
                  LIMIT 10 OFFSET ?`
-            ).bind(user, Number(user), offset || 0).all<PostView>();
+            ).bind(user, Number(user), offset).all<PostView>();
 
             return c.json(results.results, { status: 200 });
         } else {
@@ -287,7 +276,7 @@ export async function getPostsByUser(c: Context) {
                     OR pv.author_id = ?
                  ORDER BY pv.post_time DESC
                  LIMIT 10 OFFSET ?`
-            ).bind(userId, user, Number(user), offset || 0).all<PostView>();
+            ).bind(userId, user, Number(user), offset).all<PostView>();
 
             return c.json(results.results, { status: 200 });
         }

--- a/server/src/v3/controllers/post.controller.ts
+++ b/server/src/v3/controllers/post.controller.ts
@@ -96,6 +96,11 @@ export async function getLatestPosts(c: Context) {
             // Returning user, show posts with likes
             const posts = await env.DB.prepare(
                 `SELECT pv.*
+                `SELECT pv.*,
+                        EXISTS (SELECT 1
+                                FROM post_like
+                                WHERE post_like.post_id = pv.id
+                                  AND post_like.user_id = ?) AS liked
                  FROM post_view AS pv
                  ORDER BY pv.post_time DESC
                  LIMIT 10 OFFSET ?`

--- a/server/src/v3/controllers/subcomment.controller.ts
+++ b/server/src/v3/controllers/subcomment.controller.ts
@@ -65,7 +65,7 @@ export async function getSubcommentsOnComment(c: Context) {
     // Get the required fields
     const env: Env = c.env;
     const commentID: number = Number(c.req.param('cid'));
-    const page: number = c.req.query('page') ? Number(c.req.query('page')) : 0;
+    const offset: number = c.req.query('offset') ? Number(c.req.query('offset')) : 0;
 
     // Check for required fields
     if (!commentID) return c.text('No comment ID provided', { status: 400 });
@@ -79,7 +79,7 @@ export async function getSubcommentsOnComment(c: Context) {
                  WHERE parent_comment_id = ?
                  ORDER BY like_count DESC
                  LIMIT 10 OFFSET ?`
-            ).bind(commentID, page).all<CommentView>();
+            ).bind(commentID, offset).all<CommentView>();
 
             return c.json(subcomments.results, { status: 200 });
         } else {
@@ -96,7 +96,7 @@ export async function getSubcommentsOnComment(c: Context) {
                  WHERE parent_comment_id = ?
                  ORDER BY like_count DESC
                  LIMIT 10 OFFSET ?`
-            ).bind(userId, commentID, page).all<CommentView>();
+            ).bind(userId, commentID, offset).all<CommentView>();
 
             return c.json(subcomments.results, { status: 200 });
         }

--- a/server/src/v3/middleware/index.ts
+++ b/server/src/v3/middleware/index.ts
@@ -1,0 +1,3 @@
+export { authMiddlewareCheckOnly, authMiddleware } from './authentication';
+export { postRateLimitMiddleware, uploadAttachmentLimitMiddleware } from './ratelimit';
+export { textContentModerationMiddleware } from './moderation';

--- a/server/src/v3/middleware/moderation.ts
+++ b/server/src/v3/middleware/moderation.ts
@@ -1,0 +1,26 @@
+import { Context } from 'hono';
+import { createMiddleware } from 'hono/factory';
+
+export const textContentModerationMiddleware = createMiddleware(
+    async (c: Context, next) => {
+        let content;
+
+        // Parser FormBody
+        if (c.req.header('Content-Type')?.includes('multipart/form-data') || c.req.header('Content-Type')?.includes('application/x-www-form-urlencoded')) {
+            const formData = await c.req.parseBody();
+            content = formData['content'] as string;
+        } else {
+            return c.json({ message: 'Unsupported content type', status: 400 }, 400);
+        }
+
+        // No content?
+        if (!content) return c.json({ message: 'No content provided', status: 400 }, 400);
+
+        // 1984
+        // TODO Currently unimplemented, thinking whether we want to do this or not
+
+        c.set('moderatedContent', content);
+
+        await next();
+    }
+);

--- a/server/src/v3/middleware/ratelimit.ts
+++ b/server/src/v3/middleware/ratelimit.ts
@@ -1,0 +1,40 @@
+import { createMiddleware } from 'hono/factory';
+import { getSignedCookie } from 'hono/cookie';
+import { Context } from 'hono';
+
+export const postRateLimitMiddleware = createMiddleware(
+    async (c: Context, next) => {
+        const env: Env = c.env;
+        const sessionKey = await getSignedCookie(c, env.EN_SECRET, 'sessionKey') as string;
+        const { success } = await env.POSTS_RL.limit({ key: `postRequests_${sessionKey}` });
+        if (!success) {
+            return c.json({ success: false, message: 'Rate limit exceeded', status: 429, results: [] }, 429);
+        }
+
+        await next();
+    }
+);
+
+export const getPostsRateLimitMiddleware = createMiddleware(
+    async (c: Context, next) => {
+        const env: Env = c.env;
+        const sessionKey = await getSignedCookie(c, env.EN_SECRET, 'sessionKey') as string;
+        console.log(sessionKey);
+        // TODO
+
+        await next();
+    }
+)
+
+export const uploadAttachmentLimitMiddleware = createMiddleware(
+    async (c: Context, next) => {
+        const env: Env = c.env;
+        const sessionKey = await getSignedCookie(c, env.EN_SECRET, 'sessionKey') as string;
+        const { success } = await env.ATTACHMENT_RL.limit({ key: `postRequests_${sessionKey}` });
+        if (!success) {
+            return c.json({ success: false, message: 'Rate limit exceeded', status: 429, results: [] }, 429);
+        }
+
+        await next();
+    }
+);

--- a/server/src/v3/routes/attachment.ts
+++ b/server/src/v3/routes/attachment.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Context, Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import {
     deleteAttachment,
@@ -6,21 +6,21 @@ import {
     uploadAttachment,
     uploadIcon
 } from '../controllers/attachment.controller';
-import { authMiddleware, authMiddlewareCheckOnly, uploadAttachmentLimitMiddleware } from '../util/middleware';
+import { authMiddleware, authMiddlewareCheckOnly, uploadAttachmentLimitMiddleware } from '../middleware';
 
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.post('/', uploadAttachmentLimitMiddleware, authMiddleware, (c) => uploadAttachment(c), bodyLimit({
+app.post('/', uploadAttachmentLimitMiddleware, authMiddleware, (c: Context) => uploadAttachment(c), bodyLimit({
     maxSize: 10 * 1024 * 1024,
-    onError: (c) => c.text('File too large', 400)
+    onError: (c: Context) => c.text('File too large', 400)
 }));
-app.get('/:filename', (c) => getAttachmentDetails(c));
-app.delete('/:filename', authMiddlewareCheckOnly, (c) => deleteAttachment(c));
+app.get('/:filename', (c: Context) => getAttachmentDetails(c));
+app.delete('/:filename', authMiddlewareCheckOnly, (c: Context) => deleteAttachment(c));
 
-app.post('/icon', uploadAttachmentLimitMiddleware, authMiddlewareCheckOnly, (c) => uploadIcon(c), bodyLimit({
+app.post('/icon', uploadAttachmentLimitMiddleware, authMiddlewareCheckOnly, (c: Context) => uploadIcon(c), bodyLimit({
     maxSize: 5 * 1024 * 1024,
-    onError: (c) => c.text('File too large', 400)
+    onError: (c: Context) => c.text('File too large', 400)
 }));
 
 export default app;

--- a/server/src/v3/routes/auth.ts
+++ b/server/src/v3/routes/auth.ts
@@ -1,30 +1,33 @@
 import { Context, Hono } from 'hono';
 import { authMiddlewareCheckOnly } from '../middleware';
 import {
-    anonSignup,
     authenticateUser,
     authenticateWithGoogle,
+    forceLogout,
     isAnon,
     isUser,
     login,
-    logout,
-    signup
+    logout, sendEmailVerification,
+    signup, verifyEmail
 } from '../controllers/auth.controller';
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.get('/me', authMiddlewareCheckOnly, (c) => authenticateUser(c));
-app.post('/signup', authMiddlewareCheckOnly, (c) => signup(c));
-app.post('/google', authMiddlewareCheckOnly, (c) => authenticateWithGoogle(c));
-app.post('/login', authMiddlewareCheckOnly, (c) => login(c));
-app.get('/logout', authMiddlewareCheckOnly, (c) => logout(c));
-app.get('/anon', authMiddlewareCheckOnly, (c) => anonSignup(c) as Promise<never>);
-app.get('/isUser', (c) => isUser(c));
-app.get('/isAnon', authMiddlewareCheckOnly, (c) => isAnon(c));
 // Login & Signup
 app.post('/signup', authMiddlewareCheckOnly, (c: Context) => signup(c));
 app.post('/google', authMiddlewareCheckOnly, (c: Context) => authenticateWithGoogle(c));
 app.post('/login', authMiddlewareCheckOnly, (c: Context) => login(c));
+app.get('/logout', authMiddlewareCheckOnly, (c: Context) => {
+    const force = c.req.query('force');
+    if (force) return forceLogout(c);
+    return logout(c);
+});
+// app.get('/anon', authMiddlewareCheckOnly, (c: Context) => anonSignup(c) as Promise<never>);
+
+// Email
+app.post('/sendEmailVerification', authMiddlewareCheckOnly, (c: Context) => sendEmailVerification(c));
+app.get('/verifyEmail', authMiddlewareCheckOnly, (c: Context) => verifyEmail(c));
+
 // User data
 
 app.get('/me', authMiddlewareCheckOnly, (c: Context) => authenticateUser(c));

--- a/server/src/v3/routes/auth.ts
+++ b/server/src/v3/routes/auth.ts
@@ -1,5 +1,5 @@
-import { Hono } from 'hono';
-import { authMiddlewareCheckOnly } from '../util/middleware';
+import { Context, Hono } from 'hono';
+import { authMiddlewareCheckOnly } from '../middleware';
 import {
     anonSignup,
     authenticateUser,
@@ -21,5 +21,14 @@ app.get('/logout', authMiddlewareCheckOnly, (c) => logout(c));
 app.get('/anon', authMiddlewareCheckOnly, (c) => anonSignup(c) as Promise<never>);
 app.get('/isUser', (c) => isUser(c));
 app.get('/isAnon', authMiddlewareCheckOnly, (c) => isAnon(c));
+// Login & Signup
+app.post('/signup', authMiddlewareCheckOnly, (c: Context) => signup(c));
+app.post('/google', authMiddlewareCheckOnly, (c: Context) => authenticateWithGoogle(c));
+app.post('/login', authMiddlewareCheckOnly, (c: Context) => login(c));
+// User data
+
+app.get('/me', authMiddlewareCheckOnly, (c: Context) => authenticateUser(c));
+app.get('/isUser', (c: Context) => isUser(c));
+app.get('/isAnon', authMiddlewareCheckOnly, (c: Context) => isAnon(c));
 
 export default app;

--- a/server/src/v3/routes/comment.ts
+++ b/server/src/v3/routes/comment.ts
@@ -1,13 +1,13 @@
-import { Hono } from 'hono';
-import { authMiddleware, authMiddlewareCheckOnly } from '../util/middleware';
+import { Context, Hono } from 'hono';
+import { authMiddleware, authMiddlewareCheckOnly } from '../middleware';
 import { comment, deleteComment, getCommentsOnPost, likeComment } from '../controllers/comment.controller';
 
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.post('/', authMiddleware, (c) => comment(c));
-app.post('/like/:commentId', authMiddleware, (c) => likeComment(c));
-app.get('/:postId', authMiddlewareCheckOnly, (c) => getCommentsOnPost(c));
-app.delete('/:commentId', authMiddlewareCheckOnly, (c) => deleteComment(c));
+app.post('/', authMiddleware, (c: Context) => comment(c));
+app.post('/like/:commentId', authMiddleware, (c: Context) => likeComment(c));
+app.get('/:postId', authMiddlewareCheckOnly, (c: Context) => getCommentsOnPost(c));
+app.delete('/:commentId', authMiddlewareCheckOnly, (c: Context) => deleteComment(c));
 
 export default app;

--- a/server/src/v3/routes/community.ts
+++ b/server/src/v3/routes/community.ts
@@ -1,5 +1,5 @@
-import { Hono } from 'hono';
-import { authMiddlewareCheckOnly } from '../util/middleware';
+import { Context, Hono } from 'hono';
+import { authMiddlewareCheckOnly } from '../middleware';
 import {
     addAdminToCommunity,
     communityExists,
@@ -30,7 +30,7 @@ const app = new Hono<{ Bindings: Env }>();
 
 // Create Community
 app.post('/',
-    validator('form', (value, c) => {
+    validator('form', (value, c: Context) => {
         const parsed = communitySchema.safeParse(value);
         if (!parsed.success) {
             return c.text('Invalid community data', 400);
@@ -38,13 +38,13 @@ app.post('/',
         return parsed.data;
     }),
     authMiddlewareCheckOnly,
-    (c) => createCommunity(c));
+    (c: Context) => createCommunity(c));
 
 // Community Memberships
-app.post('/join/:id', authMiddlewareCheckOnly, (c) => joinCommunity(c));
-app.post('/leave/:id', authMiddlewareCheckOnly, (c) => leaveCommunity(c));
+app.post('/join/:id', authMiddlewareCheckOnly, (c: Context) => joinCommunity(c));
+app.post('/leave/:id', authMiddlewareCheckOnly, (c: Context) => leaveCommunity(c));
 app.post('/invite',
-    validator('form', (value, c) => {
+    validator('form', (value, c: Context) => {
         const parsed = communityInviteSchema.safeParse(value);
         if (!parsed.success) {
             return c.text('Invalid invite data', 400);
@@ -52,13 +52,13 @@ app.post('/invite',
         return parsed.data;
     }),
     authMiddlewareCheckOnly,
-    (c) => inviteUserToCommunity(c));
-app.get('/getMembers/:id', authMiddlewareCheckOnly, (c) => getCommunityMembers(c));
-// app.post('/addMember/:id/:userId', (c) => addMemberToCommunity(c));
-app.delete('/removeMember/:id/:userId', authMiddlewareCheckOnly, (c) => removeMemberFromCommunity(c));
+    (c: Context) => inviteUserToCommunity(c));
+app.get('/getMembers/:id', authMiddlewareCheckOnly, (c: Context) => getCommunityMembers(c));
+// app.post('/addMember/:id/:userId', (c: Context) => addMemberToCommunity(c));
+app.delete('/removeMember/:id/:userId', authMiddlewareCheckOnly, (c: Context) => removeMemberFromCommunity(c));
 
 // Get Community Posts
-app.get('/posts/:id', authMiddlewareCheckOnly, (c) => {
+app.get('/posts/:id', authMiddlewareCheckOnly, (c: Context) => {
     const { sortBy } = c.req.query();
     switch (sortBy) {
         case 'best':
@@ -70,7 +70,7 @@ app.get('/posts/:id', authMiddlewareCheckOnly, (c) => {
 });
 
 // Get Communities
-app.get('/getCommunities', authMiddlewareCheckOnly, (c) => {
+app.get('/getCommunities', authMiddlewareCheckOnly, (c: Context) => {
     const { sortBy } = c.req.query();
     switch (sortBy) {
         case 'latest':
@@ -82,16 +82,16 @@ app.get('/getCommunities', authMiddlewareCheckOnly, (c) => {
             return getCommunitiesSortByMembers(c);
     }
 });
-app.get('/getCommunitiesByTag', authMiddlewareCheckOnly, (c) => getCommunitiesByTag(c));
-app.get('/getCommunitiesByTags', authMiddlewareCheckOnly, (c) => getCommunitiesByTags(c));
-app.get('/searchCommunities', authMiddlewareCheckOnly, (c) => searchCommunities(c));
-app.get('/getCommunityByName/:name', authMiddlewareCheckOnly, (c) => getCommunityByName(c));
-app.get('/:id', authMiddlewareCheckOnly, (c) => getCommunityById(c));
-app.get('/exists/:name', (c) => communityExists(c));
+app.get('/getCommunitiesByTag', authMiddlewareCheckOnly, (c: Context) => getCommunitiesByTag(c));
+app.get('/getCommunitiesByTags', authMiddlewareCheckOnly, (c: Context) => getCommunitiesByTags(c));
+app.get('/searchCommunities', authMiddlewareCheckOnly, (c: Context) => searchCommunities(c));
+app.get('/getCommunityByName/:name', authMiddlewareCheckOnly, (c: Context) => getCommunityByName(c));
+app.get('/:id', authMiddlewareCheckOnly, (c: Context) => getCommunityById(c));
+app.get('/exists/:name', (c: Context) => communityExists(c));
 
 // Edit Community
 app.post('/:id',
-    validator('form', (value, c) => {
+    validator('form', (value, c: Context) => {
         const parsed = communityEditingSchema.safeParse(value);
         if (!parsed.success) {
             // if false positive, check the tags rule
@@ -100,9 +100,9 @@ app.post('/:id',
         return parsed.data;
     }),
     authMiddlewareCheckOnly,
-    (c) => editCommunity(c));
+    (c: Context) => editCommunity(c));
 app.post('/addAdmin',
-    validator('form', (value, c) => {
+    validator('form', (value, c: Context) => {
         const parsed = communityInviteSchema.safeParse(value);
         if (!parsed.success) {
             return c.text('Invalid invite data', 400);
@@ -110,9 +110,9 @@ app.post('/addAdmin',
         return parsed.data;
     }),
     authMiddlewareCheckOnly,
-    (c) => addAdminToCommunity(c));
+    (c: Context) => addAdminToCommunity(c));
 
 // Delete Community
-app.delete('/:id', authMiddlewareCheckOnly, (c) => deleteCommunity(c));
+app.delete('/:id', authMiddlewareCheckOnly, (c: Context) => deleteCommunity(c));
 
 export default app;

--- a/server/src/v3/routes/notification.ts
+++ b/server/src/v3/routes/notification.ts
@@ -1,11 +1,11 @@
-import { Hono } from 'hono';
+import { Context, Hono } from 'hono';
 import { getNotifications, readNotifications } from '../controllers/notification.controller';
-import { authMiddlewareCheckOnly } from '../util/middleware';
+import { authMiddlewareCheckOnly } from '../middleware';
 
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.get('/', authMiddlewareCheckOnly, (c) => getNotifications(c));
-app.post('/read', authMiddlewareCheckOnly, (c) => readNotifications(c));
+app.get('/', authMiddlewareCheckOnly, (c: Context) => getNotifications(c));
+app.post('/read', authMiddlewareCheckOnly, (c: Context) => readNotifications(c));
 
 export default app;

--- a/server/src/v3/routes/post.ts
+++ b/server/src/v3/routes/post.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Context, Hono } from 'hono';
 import {
     createPost,
     deletePost,
@@ -11,7 +11,7 @@ import {
     likePost,
     searchPosts
 } from '../controllers/post.controller';
-import { authMiddleware, authMiddlewareCheckOnly, postRateLimitMiddleware } from '../util/middleware';
+import { authMiddleware, authMiddlewareCheckOnly, postRateLimitMiddleware } from '../middleware';
 
 
 const app = new Hono<{ Bindings: Env }>();
@@ -19,19 +19,19 @@ const app = new Hono<{ Bindings: Env }>();
 // spent an hour trying to figure out why /latest/:page? works but /latest doesn't
 // do NOT place any route with parameters above /latest/:page? or the parameterless route will break, with your bones
 
-app.post('/', postRateLimitMiddleware, authMiddleware, (c) => createPost(c));
-app.delete('/:id', authMiddlewareCheckOnly, (c) => deletePost(c));
-app.post('/like/:id', authMiddleware, (c) => likePost(c));
+app.post('/', postRateLimitMiddleware, authMiddleware, (c: Context) => createPost(c));
+app.delete('/:id', authMiddlewareCheckOnly, (c: Context) => deletePost(c));
+app.post('/like/:id', authMiddleware, (c: Context) => likePost(c));
 
-app.get('/latest', authMiddlewareCheckOnly, (c) => getLatestPosts(c));
-app.get('/best', authMiddlewareCheckOnly, (c) => getBestPosts(c));
+app.get('/latest', authMiddlewareCheckOnly, (c: Context) => getLatestPosts(c));
+app.get('/best', authMiddlewareCheckOnly, (c: Context) => getBestPosts(c));
 
-app.get('/myLatest', authMiddlewareCheckOnly, (c) => getLatestPostsFromMyCommunities(c));
-app.get('/myBest', authMiddlewareCheckOnly, (c) => getBestPostsFromMyCommunities(c));
+app.get('/myLatest', authMiddlewareCheckOnly, (c: Context) => getLatestPostsFromMyCommunities(c));
+app.get('/myBest', authMiddlewareCheckOnly, (c: Context) => getBestPostsFromMyCommunities(c));
 
-app.get('/search', (c) => searchPosts(c));
+app.get('/search', (c: Context) => searchPosts(c));
 
-app.get('/user/:user', authMiddlewareCheckOnly, (c) => getPostsByUser(c));
-app.get('/:id', authMiddlewareCheckOnly, (c) => getPostByID(c));
+app.get('/user/:user', authMiddlewareCheckOnly, (c: Context) => getPostsByUser(c));
+app.get('/:id', authMiddlewareCheckOnly, (c: Context) => getPostByID(c));
 
 export default app;

--- a/server/src/v3/routes/subcomment.ts
+++ b/server/src/v3/routes/subcomment.ts
@@ -1,5 +1,5 @@
-import { Hono } from 'hono';
-import { authMiddleware, authMiddlewareCheckOnly, postRateLimitMiddleware } from '../util/middleware';
+import { Context, Hono } from 'hono';
+import { authMiddleware, authMiddlewareCheckOnly, postRateLimitMiddleware } from '../middleware';
 import {
     deleteSubcomment,
     getSubcommentsOnComment,
@@ -10,9 +10,9 @@ import {
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.post('/', postRateLimitMiddleware, authMiddleware, (c) => subcomment(c));
-app.post('/like/:scid', authMiddleware, (c) => likeSubcomment(c));
-app.get('/:cid', authMiddlewareCheckOnly, (c) => getSubcommentsOnComment(c));
-app.delete('/:scid', authMiddlewareCheckOnly, (c) => deleteSubcomment(c));
+app.post('/', postRateLimitMiddleware, authMiddleware, (c: Context) => subcomment(c));
+app.post('/like/:scid', authMiddleware, (c: Context) => likeSubcomment(c));
+app.get('/:cid', authMiddlewareCheckOnly, (c: Context) => getSubcommentsOnComment(c));
+app.delete('/:scid', authMiddlewareCheckOnly, (c: Context) => deleteSubcomment(c));
 
 export default app;

--- a/server/src/v3/routes/tags.ts
+++ b/server/src/v3/routes/tags.ts
@@ -1,8 +1,8 @@
-import { Hono } from 'hono';
+import { Context, Hono } from 'hono';
 import { getTags } from '../controllers/tags.controller';
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.get('/', (c) => getTags(c));
+app.get('/', (c: Context) => getTags(c));
 
 export default app;

--- a/server/src/v3/routes/user.ts
+++ b/server/src/v3/routes/user.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Context, Hono } from 'hono';
 import {
     editCurrentUser,
     getCurrentUser,
@@ -10,14 +10,14 @@ import {
     getUserCommunities,
     searchUser
 } from '../controllers/user.controller';
-import { authMiddlewareCheckOnly } from '../util/middleware';
+import { authMiddlewareCheckOnly } from '../middleware';
 import { validator } from 'hono/validator';
 import { userEditingSchema } from '../util/validationSchemas';
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.get('/', authMiddlewareCheckOnly, (c) => getCurrentUser(c));
-app.get('/likes', authMiddlewareCheckOnly, (c) => {
+app.get('/', authMiddlewareCheckOnly, (c: Context) => getCurrentUser(c));
+app.get('/likes', authMiddlewareCheckOnly, (c: Context) => {
     const type = c.req.query('type');
     switch (type) {
         case 'comments':
@@ -29,11 +29,13 @@ app.get('/likes', authMiddlewareCheckOnly, (c) => {
             return getCurrentUserLikesOnPosts(c);
     }
 });
-app.get('/communities', authMiddlewareCheckOnly, (c) => getCurrentUserCommunities(c));
+app.get('/communities', authMiddlewareCheckOnly, (c: Context) => getCurrentUserCommunities(c));
 
 app.get('/search', (c) => searchUser(c));
 app.get('/:userId/communities', authMiddlewareCheckOnly, (c) => getUserCommunities(c));
 app.get('/:username', (c) => getUserByUsername(c));
+app.get('/:userId/communities', authMiddlewareCheckOnly, (c: Context) => getUserCommunities(c));
+app.get('/:username', (c: Context) => getUserByUsername(c));
 
 app.post('/',
     validator('json', (value, c: Context) => {
@@ -43,6 +45,6 @@ app.post('/',
         }
         return parsed.data;
     }), authMiddlewareCheckOnly,
-    (c) => editCurrentUser(c));
+    (c: Context) => editCurrentUser(c));
 
 export default app;

--- a/server/src/v3/routes/user.ts
+++ b/server/src/v3/routes/user.ts
@@ -36,7 +36,7 @@ app.get('/:userId/communities', authMiddlewareCheckOnly, (c) => getUserCommuniti
 app.get('/:username', (c) => getUserByUsername(c));
 
 app.post('/',
-    validator('form', (value, c) => {
+    validator('json', (value, c: Context) => {
         const parsed = userEditingSchema.safeParse(value);
         if (!parsed.success) {
             return c.text('Invalid user data', 400);

--- a/server/src/v3/routes/user.ts
+++ b/server/src/v3/routes/user.ts
@@ -8,7 +8,7 @@ import {
     getCurrentUserLikesOnSubcomments,
     getUserByUsername,
     getUserCommunities,
-    searchUser
+    searchUser, searchUserForCommunity
 } from '../controllers/user.controller';
 import { authMiddlewareCheckOnly } from '../middleware';
 import { validator } from 'hono/validator';
@@ -31,9 +31,14 @@ app.get('/likes', authMiddlewareCheckOnly, (c: Context) => {
 });
 app.get('/communities', authMiddlewareCheckOnly, (c: Context) => getCurrentUserCommunities(c));
 
-app.get('/search', (c) => searchUser(c));
-app.get('/:userId/communities', authMiddlewareCheckOnly, (c) => getUserCommunities(c));
-app.get('/:username', (c) => getUserByUsername(c));
+app.get('/search', (c: Context) => {
+    const communityId = c.req.query('communityId');
+    if (communityId) {
+        return searchUserForCommunity(c);
+    } else {
+        return searchUser(c)
+    }
+});
 app.get('/:userId/communities', authMiddlewareCheckOnly, (c: Context) => getUserCommunities(c));
 app.get('/:username', (c: Context) => getUserByUsername(c));
 

--- a/server/src/v3/routes/websocket.ts
+++ b/server/src/v3/routes/websocket.ts
@@ -1,15 +1,15 @@
-import { Hono } from 'hono';
+import { Context, Hono } from 'hono';
 import {
     createWebSocketEntry,
     deleteWebSocketEntry,
     getUserIdFromWebSocketId
 } from '../controllers/websocket.controller';
-import { authMiddlewareCheckOnly } from '../util/middleware';
+import { authMiddlewareCheckOnly } from '../middleware';
 
 const app = new Hono<{ Bindings: Env }>();
 
-app.get('/:uuid', (c) => getUserIdFromWebSocketId(c));
-app.post('/', authMiddlewareCheckOnly, (c) => createWebSocketEntry(c));
-app.delete('/:uuid', authMiddlewareCheckOnly, (c) => deleteWebSocketEntry(c));
+app.get('/:uuid', (c: Context) => getUserIdFromWebSocketId(c));
+app.post('/', authMiddlewareCheckOnly, (c: Context) => createWebSocketEntry(c));
+app.delete('/:uuid', authMiddlewareCheckOnly, (c: Context) => deleteWebSocketEntry(c));
 
 export default app;

--- a/server/src/v3/util/index.d.ts
+++ b/server/src/v3/util/index.d.ts
@@ -3,6 +3,7 @@ type UserRow = {
     username: string;
     displayName: string;
     email: string;
+    email_verified: boolean;
     auth_provider: string;
     password: string;
     salt: string;
@@ -17,6 +18,7 @@ type UserView = {
     id: number;
     username: string;
     displayName: string;
+    email_verified: boolean;
     auth_provider: string;
     created_at: string;
     bio?: string;

--- a/server/src/v3/util/index.d.ts
+++ b/server/src/v3/util/index.d.ts
@@ -139,6 +139,14 @@ type SessionRow = {
     ip: string;
 }
 
+type EmailVerificationRow = {
+    token: string;
+    user_id: number;
+    email: string;
+    used: boolean;
+    created_at: number;
+}
+
 type WebSocketRow = {
     user_id: number;
     socket_id: string;

--- a/server/worker-configuration.d.ts
+++ b/server/worker-configuration.d.ts
@@ -13,4 +13,5 @@ interface Env {
     SYSTEM: string;
     CLIENT_ID: string;
     CLIENT_SECRET: string;
+    EMAIL_API: string;
 }


### PR DESCRIPTION
- New `/auth/logout?force=true` endpoint for clearing cookies regardless of current status
  - Returns 200
- New `/auth/sendEmailVerification` endpoint for sending verification emails
  - Returns `{ message: 'Email sent', status: 200 }` or `{ message: 'Internal Server Error', status: 500 }`
- New `/auth/verifyEmail?token={TOKEN}` endpoint for verifying emails given a token from the above endpoint
  - Returns `{ message: 'Email verified', status: 200 }` or `{ message: MSG, status: 400 }` where `MSG` can be one of:
    - 'Invalid token' for invalid tokens
    - 'Token already used' for used tokens
    - 'Token expired' for expired tokens
- Option to search for a user in community (Exclude members & anon users) using `/user/search?query={QUERY}&communityId={COMMUNITY_ID}?offset={OPTIONAL NUMBER}`
- Use hussain's offset instead of pages
- Phase out JWT after DB wipe