### PR TITLE
Refresh lockfiles and CI install flow

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -403,8 +403,7 @@
             "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250927.0.tgz",
             "integrity": "sha512-XcFVTMNhHROLQ+AbmK6KQuis72iGCdQXrjVl2xX98ac7w3fzUiNfTsu+SKBXN9dSEjgJEhhj0EXSAXh0b8lSww==",
             "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "peer": true
+            "license": "MIT OR Apache-2.0"
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -2212,7 +2211,6 @@
             "integrity": "sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/utils": "3.1.4",
                 "pathe": "^2.0.3"
@@ -2227,7 +2225,6 @@
             "integrity": "sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/pretty-format": "3.1.4",
                 "magic-string": "^0.30.17",
@@ -2361,7 +2358,6 @@
             "integrity": "sha512-LPVCX4If8nAy1OERzmFx/pVr4g6olBqbz30SoLTkVJu5m5WH5GkhbIKnucQ1e5ZbpfNh+nrsFM2dolXO8ow4PQ==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/util-utf8-browser": "^3.259.0",
                 "@httptoolkit/websocket-stream": "^6.0.1",
@@ -3173,8 +3169,7 @@
             "version": "2.16.9",
             "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.9.tgz",
             "integrity": "sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -3420,7 +3415,6 @@
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.6.tgz",
             "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -3614,7 +3608,8 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-bigint": {
             "version": "1.0.0",
@@ -3670,6 +3665,7 @@
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             },
@@ -3993,6 +3989,7 @@
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4072,7 +4069,6 @@
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4689,7 +4685,6 @@
             "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "defu": "^6.1.4",
                 "exsolve": "^1.0.7",
@@ -4723,7 +4718,6 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -4822,7 +4816,6 @@
             "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "3.1.4",
                 "@vitest/mocker": "3.1.4",
@@ -4938,7 +4931,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "workerd": "bin/workerd"
             },
@@ -5028,7 +5020,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
             "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/websocket-server/tsconfig.json
+++ b/websocket-server/tsconfig.json
@@ -28,7 +28,8 @@
         /* Modules */
         "module": "commonjs",
         /* Specify what module code is generated. */
-        // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+        "rootDir": "./src",
+        /* Specify the root folder within your source files. */
         // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
         // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
         // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */


### PR DESCRIPTION
## Summary
- Refreshed npm lockfiles across `client`, `client-admin`, and `server`.
- Updated GitHub Actions workflows to use older checkout/setup-node actions and `npm install` for dependency installation.
- Added Vite config updates for the client apps and adjusted admin layout navigation to redirect via `navigate()`.
- Removed the local `.claude/` ignore entry and made a small websocket server tsconfig update.

## Testing
- Not run.
- CI workflow changes were not validated locally.
- Lockfile-only changes were not separately exercised beyond the recorded build configuration updates.