### PR TITLE
Migrate to local auth and expand moderation tools

### DIFF
--- a/client/src/assets/community-default.svg
+++ b/client/src/assets/community-default.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 280" role="img" aria-label="Default community icon">
+  <rect width="280" height="280" rx="56" fill="#fff4ec"/>
+  <circle cx="140" cy="140" r="94" fill="#ffffff"/>
+  <circle cx="140" cy="104" r="34" fill="#ff7115"/>
+  <circle cx="92" cy="128" r="26" fill="#00a19a"/>
+  <circle cx="188" cy="128" r="26" fill="#2f4858"/>
+  <path d="M73 206c6-41 31-62 67-62s61 21 67 62" fill="#ff7115"/>
+  <path d="M42 205c5-31 24-47 50-47 13 0 25 4 34 13-15 10-25 24-30 43H42z" fill="#00a19a"/>
+  <path d="M184 171c9-9 21-13 34-13 26 0 45 16 50 47h-54c-5-19-15-33-30-43z" fill="#2f4858"/>
+  <path d="M74 58h132c18 0 32 14 32 32v77c0 18-14 32-32 32h-16l-36 30v-30H74c-18 0-32-14-32-32V90c0-18 14-32 32-32z" fill="none" stroke="#ff7115" stroke-width="12" stroke-linejoin="round"/>
+</svg>

--- a/client/src/components/Admin/Dashboard/Dashboard.tsx
+++ b/client/src/components/Admin/Dashboard/Dashboard.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { assetsBase } from '../../../api/api.ts';
 import { getAdminStats } from '../../../api/admin';
 import styles from './Dashboard.module.scss';
-import defaultCommunityIcon from '../../../assets/community-icon.jpg';
+import defaultCommunityIcon from '../../../assets/community-default.svg';
 
 export default function Dashboard() {
     const navigate = useNavigate();

--- a/client/src/components/PostStuff/Editor/Editor.tsx
+++ b/client/src/components/PostStuff/Editor/Editor.tsx
@@ -90,12 +90,11 @@ export default function Editor({
     const [selectedCommunity, setSelectedCommunity] = useState<CommunityINI>();
     const [loadingUserCommunities, setLoadingUserCommunities] =
         useState<boolean>(false);
-    const selectCommunityButtonRef = useRef<HTMLButtonElement>(null);
     const selectCommunityInputRef = useRef<HTMLInputElement>(null);
     const imageInputRef = useRef<HTMLInputElement>(null);
     const editorContainerRef = useRef<HTMLDivElement | null>(null);
     const editorHelperRef = useRef<{ clearEditorContent: () => void }>(null);
-    const { user, isUser, isSuspended } = useUser();
+    const { isUser, isSuspended } = useUser();
     const [showSuspendedPopUp, setShowSuspendedPopUp] = useState<boolean>(false);
 
 
@@ -247,19 +246,14 @@ export default function Editor({
                 if (communityId !== undefined) {
                     console.log("there is a community id");
                     post = await createPost(plainText, uploadState.fileName, communityId);
-                } else if (!user || user.isAnonymous || user.new) {
-                    post = await createPost(plainText, uploadState.fileName);
-                } else if (!selectedCommunity) {
-                    selectCommunityButtonRef.current?.classList.add(
-                        styles.warning,
-                    );
-                    return;
-                } else {
+                } else if (selectedCommunity) {
                     post = await createPost(
                         plainText,
                         uploadState.fileName,
                         selectedCommunity.id,
                     );
+                } else {
+                    post = await createPost(plainText, uploadState.fileName);
                 }
                 const postInfo: PostInfo = {
                     id: post.id,
@@ -536,14 +530,13 @@ export default function Editor({
                             <button
                                 className={styles.showCommunities}
                                 onClick={handleSelectCommunityClick}
-                                ref={selectCommunityButtonRef}
                             >
                                 {selectedCommunity ? (
                                     <CommunityPreview
                                         community={selectedCommunity}
                                     />
                                 ) : (
-                                    <span>Select a community</span>
+                                    <span>General</span>
                                 )}
                                 <img
                                     src={arrowDownIcon}

--- a/client/src/components/Reusable/CommunityIconComponent/CommunityIconComponent.tsx
+++ b/client/src/components/Reusable/CommunityIconComponent/CommunityIconComponent.tsx
@@ -1,6 +1,6 @@
 import styles from "./CommunityIconComponent.module.scss";
 import { assetsBase } from "../../../api/api.ts";
-import defaultCommunityIcon from "../../../assets/community-icon.jpg";
+import defaultCommunityIcon from "../../../assets/community-default.svg";
 import {memo, SyntheticEvent} from "react";
 
 function CommunityIconComponent({

--- a/client/src/utils/tools.ts
+++ b/client/src/utils/tools.ts
@@ -68,35 +68,25 @@ export function parsePositiveInt(value: string | null): number | null {
     return parsed;
 }
 
-const colorOptions: {background: string, fontColor: string}[] = [
-    { background: "#F44336", fontColor: "white" }, // Red
-    { background: "#E91E63", fontColor: "white" }, // Pink
-    { background: "#9C27B0", fontColor: "white" }, // Purple
-    { background: "#673AB7", fontColor: "white" }, // Deep Purple
-    { background: "#3F51B5", fontColor: "white" }, // Indigo
-    { background: "#2196F3", fontColor: "white" }, // Blue
-    { background: "#03A9F4", fontColor: "black" }, // Light Blue
-    { background: "#00BCD4", fontColor: "black" }, // Cyan
-    { background: "#009688", fontColor: "white" }, // Teal
-    { background: "#4CAF50", fontColor: "white" }, // Green
-    { background: "#8BC34A", fontColor: "black" }, // Light Green
-    { background: "#CDDC39", fontColor: "black" }, // Lime
-    { background: "#FFEB3B", fontColor: "black" }, // Yellow
-    { background: "#FFC107", fontColor: "black" }, // Amber
-    { background: "#FF9800", fontColor: "black" }, // Orange
-    { background: "#FF5722", fontColor: "white" }, // Deep Orange
-    { background: "#795548", fontColor: "white" }, // Brown
-    { background: "#607D8B", fontColor: "white" }, // Blue Grey
+const communityIconPalettes: { background: string, accent: string, secondary: string, text: string }[] = [
+    { background: "#fff4ec", accent: "#ff7115", secondary: "#00a19a", text: "#2f4858" },
+    { background: "#eefaf8", accent: "#00a19a", secondary: "#ff7115", text: "#2f4858" },
+    { background: "#f4f7f9", accent: "#2f4858", secondary: "#ff7115", text: "#ffffff" },
+    { background: "#fff8dc", accent: "#f4a261", secondary: "#00a19a", text: "#2f4858" },
 ];
 
+function hashCommunityName(communityName: string) {
+    return communityName.split('').reduce((hash, char) => hash + char.charCodeAt(0), 0);
+}
 
-
-let ind: number;
 export function getDefaultIconForCommunity(communityName: string, newIcon: boolean) {
     const firstTwoLetters: string = communityName.split(" ").map((word) => word[0]).join("").slice(0, 2).toUpperCase();
     console.log("first two letters", firstTwoLetters);
-
-    if (newIcon || !ind) ind = Math.floor(Math.random() * colorOptions.length);
+    const palette = communityIconPalettes[
+        newIcon
+            ? Math.floor(Math.random() * communityIconPalettes.length)
+            : hashCommunityName(communityName) % communityIconPalettes.length
+    ];
 
     const canvas = document.createElement("canvas");
     canvas.width = 150;
@@ -104,14 +94,44 @@ export function getDefaultIconForCommunity(communityName: string, newIcon: boole
     const ctx = canvas.getContext("2d");
 
     if (ctx) {
-        ctx.fillStyle = colorOptions[ind].background;
+        ctx.fillStyle = palette.background;
         ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-        ctx.fillStyle = colorOptions[ind].fontColor;
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.font = "bold 60px Arial";
-        ctx.fillText(firstTwoLetters, canvas.width / 2, canvas.height / 2);
+        ctx.fillStyle = "#ffffff";
+        ctx.beginPath();
+        ctx.arc(75, 75, 50, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.fillStyle = palette.secondary;
+        ctx.beginPath();
+        ctx.arc(48, 72, 14, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.beginPath();
+        ctx.arc(102, 72, 14, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.fillStyle = palette.accent;
+        ctx.beginPath();
+        ctx.arc(75, 58, 20, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.fillStyle = palette.secondary;
+        ctx.beginPath();
+        ctx.roundRect(28, 88, 94, 42, 21);
+        ctx.fill();
+
+        ctx.fillStyle = palette.accent;
+        ctx.beginPath();
+        ctx.roundRect(42, 78, 66, 52, 26);
+        ctx.fill();
+
+        if (firstTwoLetters) {
+            ctx.fillStyle = palette.text;
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            ctx.font = "bold 42px Arial";
+            ctx.fillText(firstTwoLetters, canvas.width / 2, 104);
+        }
     }
     return canvas.toDataURL();
 }

--- a/server/migrations/0001_init.sql
+++ b/server/migrations/0001_init.sql
@@ -652,7 +652,8 @@ VALUES ('UAEU'),
        ('Study'),
        ('Gaming'),
        ('Hobbies'),
-       ('Jobs');
+       ('Jobs'),
+       ('Other');
 
 INSERT OR IGNORE INTO community (
     id,

--- a/server/migrations/0002_seed_other_tag.sql
+++ b/server/migrations/0002_seed_other_tag.sql
@@ -1,0 +1,2 @@
+INSERT OR IGNORE INTO tag (name)
+VALUES ('Other');

--- a/server/src/dev.schema.sql
+++ b/server/src/dev.schema.sql
@@ -652,7 +652,8 @@ VALUES ('UAEU'),
        ('Study'),
        ('Gaming'),
        ('Hobbies'),
-       ('Jobs');
+       ('Jobs'),
+       ('Other');
 
 INSERT OR IGNORE INTO community (
     id,

--- a/server/src/v3/controllers/tags.controller.ts
+++ b/server/src/v3/controllers/tags.controller.ts
@@ -31,6 +31,10 @@ export async function getOrCreateTags(c: Context, internal: boolean = false) {
         tagNames = tags.split(',').map((tag: string) => tag.trim());
     }
 
+    if (internal && tagNames.length === 0) {
+        tagNames = ['Other'];
+    }
+
     // Check if tags are empty
     if (tagNames.length === 0) {
         return c.text('Tags cannot be empty', 400);

--- a/server/src/v3/util/validationSchemas.ts
+++ b/server/src/v3/util/validationSchemas.ts
@@ -6,6 +6,14 @@ const nonEmptyText = (fieldName: string) => z.string().refine((value) => value.t
     message: `${fieldName} cannot be empty`
 });
 const optionalAssetIdSchema = z.string().regex(uuidRegex, 'Invalid asset identifier').optional();
+const communityTagsSchema = z
+    .string()
+    .optional()
+    .default('')
+    .transform((tags) => {
+        const parsedTags = tags.split(',').map((tag) => tag.trim()).filter((tag) => tag.length > 0);
+        return parsedTags.length > 0 ? parsedTags : ['Other'];
+    });
 const booleanQuerySchema = z.preprocess(
     (value) => value === undefined ? 'false' : value,
     z.enum(['true', 'false']).transform((value) => value === 'true')
@@ -33,9 +41,7 @@ export const communitySchema = z.object({
         .max(1024, 'Community description must be at most 1024 characters long'),
     icon: assetIdSchema
         .optional(),
-    tags: z.string()
-        .transform((tags) => tags.split(',').map((tag) => tag.trim()).filter((tag) => tag.length > 0))
-        .refine((tags) => tags.length > 0, { message: 'Tags cannot be empty' })
+    tags: communityTagsSchema
 
     // Currently unimplemented
 

--- a/server/test/community/create.test.ts
+++ b/server/test/community/create.test.ts
@@ -1,0 +1,70 @@
+import { env, SELF } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+
+const base = 'http://127.0.0.1:8787';
+const validAssetId = '123e4567-e89b-12d3-a456-426614174000';
+
+type CookieHeaders = Headers & { getSetCookie?: () => string[] };
+
+function cookieHeaderFrom(response: Response): string {
+    const headers = response.headers as CookieHeaders;
+    const setCookies = headers.getSetCookie?.() ?? (headers.get('set-cookie') ? [headers.get('set-cookie')!] : []);
+    return setCookies.map((cookie) => cookie.split(';')[0]).join('; ');
+}
+
+function unique(prefix: string) {
+    return `${prefix.slice(0, 8)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function signupUser() {
+    const username = unique('communityuser');
+    const response = await SELF.fetch(`${base}/auth/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            username,
+            displayname: username,
+            email: `${username}@example.com`,
+            password: 'StrongPassword-123',
+            includeAnon: false
+        })
+    });
+
+    expect(response.status).toBe(201);
+    return cookieHeaderFrom(response);
+}
+
+describe('Community creation', () => {
+    it('creates a community with the Other tag when no tags are selected', async () => {
+        const cookie = await signupUser();
+        const name = unique('community');
+        const formData = new FormData();
+        formData.append('name', name);
+        formData.append('desc', 'A community without tags');
+        formData.append('tags', '');
+        formData.append('icon', validAssetId);
+
+        const response = await SELF.fetch(`${base}/community`, {
+            method: 'POST',
+            headers: { Cookie: cookie },
+            body: formData
+        });
+
+        expect(response.status).toBe(201);
+        const body = await response.json() as { id: number };
+        const community = await env.DB.prepare(`
+            SELECT name, tags
+            FROM community
+            WHERE id = ?
+        `).bind(body.id).first<{ name: string; tags: string | null }>();
+        expect(community).toEqual({ name, tags: 'Other' });
+
+        const communityTags = await env.DB.prepare(`
+            SELECT tag.name
+            FROM community_tag
+            JOIN tag ON tag.id = community_tag.tag_id
+            WHERE community_tag.community_id = ?
+        `).bind(body.id).first<{ name: string }>();
+        expect(communityTags?.name).toBe('Other');
+    });
+});

--- a/server/test/post/create.test.ts
+++ b/server/test/post/create.test.ts
@@ -1,0 +1,60 @@
+import { env, SELF } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+
+const base = 'http://127.0.0.1:8787';
+
+type CookieHeaders = Headers & { getSetCookie?: () => string[] };
+
+function cookieHeaderFrom(response: Response): string {
+    const headers = response.headers as CookieHeaders;
+    const setCookies = headers.getSetCookie?.() ?? (headers.get('set-cookie') ? [headers.get('set-cookie')!] : []);
+    return setCookies.map((cookie) => cookie.split(';')[0]).join('; ');
+}
+
+function unique(prefix: string) {
+    return `${prefix.slice(0, 8)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function signupUser() {
+    const username = unique('postuser');
+    const response = await SELF.fetch(`${base}/auth/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            username,
+            displayname: username,
+            email: `${username}@example.com`,
+            password: 'StrongPassword-123',
+            includeAnon: false
+        })
+    });
+
+    expect(response.status).toBe(201);
+    return cookieHeaderFrom(response);
+}
+
+describe('Post creation', () => {
+    it('posts to the general community when no community is selected', async () => {
+        const cookie = await signupUser();
+        const formData = new FormData();
+        formData.append('content', 'Post without explicit community');
+
+        const response = await SELF.fetch(`${base}/post`, {
+            method: 'POST',
+            headers: { Cookie: cookie },
+            body: formData
+        });
+
+        expect(response.status).toBe(201);
+        const post = await response.json() as { id: number; community_id: number; community: string };
+        expect(post.community_id).toBe(0);
+        expect(post.community).toBe('general');
+
+        const row = await env.DB.prepare(`
+            SELECT community_id
+            FROM post
+            WHERE id = ?
+        `).bind(post.id).first<{ community_id: number }>();
+        expect(row?.community_id).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- Replaced Firebase auth with a local session-based auth flow and added supporting email/password handling.
- Consolidated the admin experience into the main client app, including dashboards, reports, feedback, and moderation actions.
- Added broader moderation and safety features for posts, comments, communities, bans, suspensions, reporting, and input hardening.
- Updated app/runtime toolchains to Node 24 and npm 11, refreshed dependencies and lockfiles, and aligned CI workflows.
- Added support for default `Other` communities/posts, PDF rendering, notification deep-links, and shared admin theme tokens.

## Testing
- `client`: build run in CI via `npm ci` and `npm run build`.
- `websocket-server`: build run in CI via `npm ci` and `npm run build`.
- `server`: added/updated tests for local auth migration, signup, email, community creation, post creation, and input hardening.
- Not run locally in this workspace.