### PR TITLE
Preserve aside icon width on narrow screens

### DIFF
--- a/client/src/components/Aside/Aside.module.scss
+++ b/client/src/components/Aside/Aside.module.scss
@@ -30,6 +30,11 @@
         transition: background-color 0.2s ease;
         font-weight: 600;
 
+        > img,
+        > svg {
+            flex-shrink: 0;
+        }
+
         &:hover {
             background-color: #eee;
             //color: white;

--- a/client/test/asideResponsiveStyles.test.mjs
+++ b/client/test/asideResponsiveStyles.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import * as sass from "sass";
+
+const asideStylesPath = join(
+    import.meta.dirname,
+    "../src/components/Aside/Aside.module.scss",
+);
+
+test("sidebar icons keep their width when labels are hidden on narrow screens", () => {
+    const source = readFileSync(asideStylesPath, "utf8");
+    const css = sass.compileString(source, { style: "expanded" }).css;
+
+    assert.match(
+        css,
+        /\.aside \.element > img,\s*\.aside \.element > svg \{[^}]*flex-shrink: 0;/s,
+    );
+});


### PR DESCRIPTION
## Summary
- Prevent aside item icons from shrinking by applying `flex-shrink: 0` to direct `img` and `svg` children.
- Add a regression test that compiles the Aside stylesheet and verifies the icon width rule is present.

## Testing
- `node --test client/test/asideResponsiveStyles.test.mjs`
- Not run: full client test suite